### PR TITLE
docs: branded README header, badges, and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,60 @@
+# AGENTS.md — @rendobar/mcp
+
+Guide for agents and humans working on the Rendobar MCP server. Companion to the monorepo guide at [rendobar/rendobar](https://github.com/rendobar/rendobar). Dev rules, build/test commands, and the MCP-specific hard bans live in [CLAUDE.md](./CLAUDE.md) — read it before changing code.
+
+## TL;DR
+
+- **What this is**: the local stdio Model Context Protocol server for Rendobar. Single ESM bundle, ~6 tools, public, MIT.
+- **SDK source**: lives in the [rendobar/rendobar](https://github.com/rendobar/rendobar) monorepo under `packages/sdk/`. Consumed here as `@rendobar/sdk` from npm.
+- **Release**: conventional commits → release-please → npm publish with provenance + `.mcpb` GitHub Release asset + official MCP registry.
+- **No manual tags, no manual version bumps.** release-please owns them.
+
+## The rules that bite (full detail in CLAUDE.md)
+
+- **Never write to stdout.** It is reserved for JSON-RPC framing; one stray byte kills the connection. Logs go to stderr.
+- **Recoverable tool failures return `{ isError: true }`, not throws.** Throw only for programmer bugs.
+- **Cold-start budget < 2 s, bundle < 100 KB.** CI asserts both. No network calls at module load.
+- **One Zod version.** The SDK uses `zod/v4`; two copies break `registerTool`. Fix the dep tree, never `as any`.
+
+## Cross-repo brand consistency
+
+This repo is part of the broader Rendobar platform. The canonical reference for brand strings, URLs, and metadata across every rendobar repo is the apex monorepo's `.claude/rules/brand-consistency.md`:
+
+https://github.com/rendobar/rendobar/blob/main/.claude/rules/brand-consistency.md
+
+### Canonical brand strings (must match apex)
+
+| Field | Value |
+|---|---|
+| Display name | `Rendobar` |
+| Slogan | `Media processing API for developers and agents` |
+| Apex URL | `https://rendobar.com` |
+| Apex page URLs | `https://rendobar.com/<path>/` (always trailing slash) |
+| API URL | `https://api.rendobar.com` |
+| Dashboard URL | `https://app.rendobar.com` |
+| CDN URL | `https://cdn.rendobar.com` |
+| Twitter handle | `@rendobar` |
+| Discord | `https://discord.gg/kAGqjBzx8N` |
+
+**Forbidden variants**: `Rendobar.com`, `rendobar` (lowercase except in URLs / package names), `https://www.rendobar.com`, `http://rendobar.com`, apex page links without a trailing slash.
+
+**Entity model**: Rendobar is a media-processing **platform**. The FFmpeg API is one product on it. Write "Rendobar's FFmpeg API", never "Rendobar is an FFmpeg API".
+
+### Writing style (README, package.json description, docs prose)
+
+No em-dash (`—`) and no semicolons in reader-facing prose. They read as AI-generated. Use a period or a comma. Sentence case, declarative, specific numbers over vague claims. Code blocks are exempt.
+
+### No AI attribution in commits / PRs
+
+Never add `Co-Authored-By: Claude`, `🤖 Generated with [Claude Code]`, or any AI attribution in commit messages or PR descriptions. Strip them silently if a template injects them.
+
+## For agents
+
+1. Confirm the build and tests are green before touching anything (commands in [CLAUDE.md](./CLAUDE.md)).
+2. Branch off `main`: `git checkout -b feat/short-name`.
+3. Make the change plus a test.
+4. Commit with a conventional message. Never use `git commit --no-verify` — fix the hook failure instead.
+5. `git push -u origin <branch>` and open a PR. Wait for CI green, merge.
+6. Walk away. release-please handles the version, tag, npm publish, and registry.
+
+**Do not**: push to `main` directly, push tags manually, edit `CHANGELOG.md` or the `version` field, or add AI attribution to commits.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,38 @@
-# @rendobar/mcp
+<p align="center">
+  <a href="https://rendobar.com">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://cdn.rendobar.com/assets/brand/logo-mark.svg">
+      <img alt="Rendobar" src="https://cdn.rendobar.com/assets/brand/logo-mark-black.svg" width="80">
+    </picture>
+  </a>
+</p>
 
-> Rendobar — serverless media processing for AI agents.
+<h1 align="center">@rendobar/mcp</h1>
+
+<p align="center">
+  <strong>Serverless media processing for AI agents.</strong><br>
+  The official Model Context Protocol server for Rendobar.
+</p>
+
+<p align="center">
+  <a href="https://rendobar.com">Website</a> &nbsp;·&nbsp;
+  <a href="https://rendobar.com/docs/mcp/">MCP docs</a> &nbsp;·&nbsp;
+  <a href="https://www.npmjs.com/package/@rendobar/mcp">npm</a> &nbsp;·&nbsp;
+  <a href="https://discord.gg/kAGqjBzx8N">Discord</a>
+</p>
+
+<p align="center">
+  <a href="https://www.npmjs.com/package/@rendobar/mcp"><img src="https://img.shields.io/npm/v/@rendobar/mcp?style=flat-square&color=059669&label=npm" alt="npm version"></a>
+  <a href="https://www.npmjs.com/package/@rendobar/mcp"><img src="https://img.shields.io/npm/dm/@rendobar/mcp?style=flat-square&color=059669" alt="npm downloads"></a>
+  <img src="https://img.shields.io/npm/l/@rendobar/mcp?style=flat-square&color=059669" alt="MIT license">
+  <img src="https://img.shields.io/node/v/@rendobar/mcp?style=flat-square&color=059669" alt="Node version">
+</p>
+
+---
 
 `@rendobar/mcp` is the official Model Context Protocol server for [Rendobar](https://rendobar.com). It lets AI agents in Claude Desktop, Cursor, Cline, Windsurf, Zed, VS Code, Claude Code, and Continue submit Rendobar jobs and upload local files in a single tool call.
+
+The difference from the hosted MCP at `api.rendobar.com`: this server runs locally, so it can read and upload files straight from your machine. An agent can take a video on your disk, run an FFmpeg job on it, and hand back the result without you touching a browser.
 
 ## Install
 
@@ -107,13 +137,22 @@ env:
 | `cancel_job` | Cancel a waiting/dispatched job. |
 | `get_account` | Check balance, plan limits, active job count. |
 
+## Local vs hosted MCP
+
+| | `@rendobar/mcp` (this package) | Hosted MCP (`api.rendobar.com`) |
+|---|---|---|
+| Transport | stdio, spawned by your client | Streamable HTTP |
+| Local file upload | Yes, the whole point | No, server has no disk |
+| Setup | `npx` line in a config file | Bearer API key over HTTP |
+| Best for | Claude Desktop, Cursor, Cline, Zed, local agents | claude.ai web, ChatGPT, hosted gateways |
+
 ## Authentication
 
 Three sources, first match wins:
 
 1. `--api-key=<key>` flag
 2. `RENDOBAR_API_KEY` environment variable
-3. `~/.config/rendobar/credentials.json` (Unix) / `%APPDATA%\rendobar\credentials.json` (Windows) — written by Rendobar CLI's `rb login` (CLI v1.1+)
+3. `~/.config/rendobar/credentials.json` (Unix) / `%APPDATA%\rendobar\credentials.json` (Windows), written by Rendobar CLI's `rb login` (CLI v1.1+)
 
 ## Troubleshooting
 
@@ -131,11 +170,11 @@ Use `"command": "npx.cmd"` instead of `"command": "npx"` if your client doesn't 
 
 ### Server fails to start
 
-Check logs in your client's output panel. Server writes JSON lines to stderr — look for entries with `level: "error"`.
+Check logs in your client's output panel. The server writes JSON lines to stderr. Look for entries with `level: "error"`.
 
 ## Contributing
 
-See [CONTRIBUTING.md](./CONTRIBUTING.md). For AI-assisted development, see [CLAUDE.md](./CLAUDE.md).
+See [CONTRIBUTING.md](./CONTRIBUTING.md). For AI-assisted development, see [AGENTS.md](./AGENTS.md) and [CLAUDE.md](./CLAUDE.md).
 
 ## License
 


### PR DESCRIPTION
Polishes the README to match the Rendobar CLI's branded header and adds an AGENTS.md so coding assistants (Cursor, Copilot, Codex, Claude Code) pick up repo conventions.

## Changes
- Branded centered header: logo (light/dark), npm version + downloads + license + node badges, nav links
- New "Local vs hosted MCP" comparison table (clarifies why this package exists)
- Removed em-dash from the intro line (writing-style rule)
- New AGENTS.md mirroring the CLI's, pointing to CLAUDE.md for dev specifics

Docs only. No code or version change.