### PR TITLE
chore: add glama.json to claim Glama listing

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "a-essawy"
+  ]
+}


### PR DESCRIPTION
Adds glama.json so the Rendobar MCP server listing on glama.ai can be claimed and marked official. Maintainer set to the repo admin account.