### PR TITLE
ci: drive release-please PRs with a PAT so CI fires and tags publish

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -3,6 +3,7 @@
   "release-type": "node",
   "include-component-in-tag": false,
   "include-v-in-tag": true,
+  "pull-request-title-pattern": "chore: release ${version}",
   "packages": {
     ".": {
       "package-name": "@rendobar/mcp",

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,6 +3,10 @@ name: release-please
 on:
   push:
     branches: [main]
+  # Manual escape hatch for the "silent release skip" failure mode. When label
+  # drift or a missed tag stalls release-please, a maintainer can re-fire it
+  # here without pushing a dummy commit to main.
+  workflow_dispatch: {}
 
 permissions:
   contents: write
@@ -12,7 +16,80 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      # PAT (not GITHUB_TOKEN) on checkout so the tag pushed by "Tag released
+      # version" triggers release.yml — tags pushed by GITHUB_TOKEN do NOT fire
+      # downstream workflows. fetch-depth: 0 is needed for git tag + push.
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           config-file: .github/release-please-config.json
           manifest-file: .github/.release-please-manifest.json
+          # PAT so the release PR is opened/updated as a real user — release
+          # PRs opened by GITHUB_TOKEN do NOT fire ci.yml's pull_request
+          # trigger, so required checks never run and the PR stays BLOCKED.
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          # Single-root-package repo ("." in the manifest) trips release-please's
+          # own github-release step: getBranchComponent() resolves to the package
+          # name while the merged PR branch carries no component, so it skips the
+          # release and never tags (upstream bug googleapis/release-please#2214,
+          # open for root paths). We let release-please own only the version PR +
+          # CHANGELOG + manifest, and create the tag ourselves below. The GitHub
+          # Release itself is created by release.yml after a successful publish.
+          skip-github-release: true
+
+      # When release-please opens/updates a release PR, auto-merge it once the
+      # required checks pass. Uses the PAT so the eventual squash-merge to main
+      # re-triggers this workflow — otherwise the merge push is attributed to
+      # github-actions[bot] and fires nothing.
+      - name: Enable auto-merge on release PR
+        if: steps.release.outputs.pr
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+        run: |
+          PR_NUMBER=$(echo '${{ steps.release.outputs.pr }}' | node -e "
+            let d = '';
+            process.stdin.on('data', c => d += c);
+            process.stdin.on('end', () => console.log(JSON.parse(d).number));
+          ")
+          gh pr merge "$PR_NUMBER" --auto --squash --repo "${{ github.repository }}" || true
+
+      # When a release PR has just merged (no new PR opened this run), push the
+      # tag so release.yml publishes to npm + the MCP registry and cuts the
+      # GitHub Release, and flip the merged PR's label to 'autorelease: tagged'
+      # so release-please stops treating it as an outstanding untagged release
+      # (which would otherwise jam every future run).
+      - name: Tag released version
+        if: ${{ !steps.release.outputs.pr }}
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+        run: |
+          SUBJECT=$(git log -1 --pretty=%s)
+          case "$SUBJECT" in
+            "chore: release"*) ;;
+            *) echo "HEAD is not a release commit ('$SUBJECT') — nothing to tag."; exit 0 ;;
+          esac
+
+          VERSION=$(node -p "require('./package.json').version")
+          TAG="v$VERSION"
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "$TAG already exists — nothing to do."
+            exit 0
+          fi
+
+          echo "Tagging $TAG at $(git rev-parse --short HEAD)"
+          git tag "$TAG"
+          git push origin "$TAG"   # PAT-authenticated push fires release.yml
+
+          # Clear the release-please bookkeeping label on the merged release PR.
+          PR=$(printf '%s' "$SUBJECT" | grep -oE '#[0-9]+' | head -1 | tr -d '#')
+          if [ -n "$PR" ]; then
+            gh pr edit "$PR" \
+              --repo "${{ github.repository }}" \
+              --remove-label "autorelease: pending" \
+              --add-label "autorelease: tagged" || true
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,31 @@ jobs:
           echo "::error::Smoke test failed after 5 attempts (last raw output above)"
           exit 1
 
+      - name: Create GitHub Release
+        # Best-effort — npm publish above is the source of truth. release-please
+        # skips its own github-release (see release-please.yml: upstream bug
+        # #2214 on root packages), so we cut the release here off the CHANGELOG
+        # it maintained. The tag already exists (pushed by release-please.yml).
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.tag.outputs.version }}
+          REF: ${{ steps.tag.outputs.ref }}
+        run: |
+          # Extract this version's section from CHANGELOG.md (release-please
+          # writes "## [X.Y.Z]" headers). Fall back to auto-generated notes.
+          NOTES=$(awk -v v="$VERSION" '
+            $0 ~ "^## \\[" v "\\]" { grab=1; next }
+            grab && /^## \[/ { exit }
+            grab { print }
+          ' CHANGELOG.md 2>/dev/null)
+          if [ -n "$NOTES" ]; then
+            printf '%s\n' "$NOTES" > /tmp/notes.md
+            gh release create "$REF" --title "$REF" --notes-file /tmp/notes.md --verify-tag
+          else
+            gh release create "$REF" --title "$REF" --generate-notes --verify-tag
+          fi
+
       - name: Publish to MCP official registry
         # Best-effort — failure here doesn't roll back npm publish.
         # mcp-publisher is a Go binary distributed via GitHub Releases (not npm).


### PR DESCRIPTION
## Problem

Release-please PR #7 (`chore: release 1.0.2`) is stuck `BLOCKED` and never auto-merged. Two chained bugs:

1. **CI never ran.** `release-please.yml` opened the PR using the default `GITHUB_TOKEN`. By GitHub''s anti-recursion rule, events from `GITHUB_TOKEN` don''t trigger other workflows — so `ci.yml`''s `pull_request` trigger never fired. `0` check runs → the 5 required status checks (`Test (…)`, `Bundle size budget`, `Cold-start budget`) stay unmet → `BLOCKED`. No auto-merge step existed either.
2. **Tags would never publish.** Even if #7 were force-merged, this single-root-package repo trips upstream bug [release-please#2214](https://github.com/googleapis/release-please/issues/2214): release-please skips its own GitHub release and never pushes a `v*` tag, so `release.yml` (npm publish) would never fire.

## Fix

Ports the proven flow already running in `rendobar/cli`:

- Run release-please under **`RELEASE_PLEASE_TOKEN`** (PAT) so the PR fires CI and the squash-merge re-triggers this workflow.
- **`skip-github-release: true`** + a manual **Tag released version** step — push the `v*` tag ourselves so `release.yml` fires (sidesteps #2214).
- **Enable auto-merge** on the release PR once required checks pass.
- Pin **`pull-request-title-pattern: "chore: release ${version}"`** so the squash commit matches the tag guard and passes `pr-title.yml`.
- Cut the **GitHub Release** in `release.yml` off the release-please CHANGELOG (since `skip-github-release` means release-please no longer creates it).
- **`workflow_dispatch`** escape hatch for the documented silent-skip failure mode.

## Prerequisites (done)

- `RELEASE_PLEASE_TOKEN` secret added to this repo.
- `allow_auto_merge` enabled on the repo.

## Test plan

After merge, run `release-please` (push to main or the dispatch hatch). Expect: a fresh release PR opened by the PAT → `ci.yml` runs the 5 checks → checks green → auto-merge squashes to main → `release-please` re-run pushes `v1.0.2` → `release.yml` publishes `@rendobar/mcp@1.0.2` to npm + cuts the GitHub Release. Then close/supersede the stale #7.