### PR TITLE
ci: use ORG_AUTOMATION_PAT for release-please (org-wide token)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          token: ${{ secrets.ORG_AUTOMATION_PAT }}
 
       - uses: googleapis/release-please-action@v4
         id: release
@@ -32,7 +32,7 @@ jobs:
           # PAT so the release PR is opened/updated as a real user — release
           # PRs opened by GITHUB_TOKEN do NOT fire ci.yml's pull_request
           # trigger, so required checks never run and the PR stays BLOCKED.
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          token: ${{ secrets.ORG_AUTOMATION_PAT }}
           # Single-root-package repo ("." in the manifest) trips release-please's
           # own github-release step: getBranchComponent() resolves to the package
           # name while the merged PR branch carries no component, so it skips the
@@ -49,7 +49,7 @@ jobs:
       - name: Enable auto-merge on release PR
         if: steps.release.outputs.pr
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          GH_TOKEN: ${{ secrets.ORG_AUTOMATION_PAT }}
         run: |
           PR_NUMBER=$(echo '${{ steps.release.outputs.pr }}' | node -e "
             let d = '';
@@ -66,7 +66,7 @@ jobs:
       - name: Tag released version
         if: ${{ !steps.release.outputs.pr }}
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          GH_TOKEN: ${{ secrets.ORG_AUTOMATION_PAT }}
         run: |
           SUBJECT=$(git log -1 --pretty=%s)
           case "$SUBJECT" in


### PR DESCRIPTION
Point release-please.yml at the org-wide `ORG_AUTOMATION_PAT` secret instead of the repo-scoped `RELEASE_PLEASE_TOKEN`. Honest name for a broad org automation token; works across all current + future repos. No behavior change — same PAT-driven flow, just the secret reference.