### PR TITLE
fix(ci): smoke retry defeated by errexit; idempotent npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,16 @@ jobs:
       - run: pnpm build
 
       - name: Publish to npm via OIDC trusted publisher
+        env:
+          VERSION: ${{ steps.tag.outputs.version }}
         run: |
+          # Idempotent: npm publish 403s on an existing version, so a recovery
+          # re-run (after a later step like smoke/registry failed) would abort
+          # here. If this version is already live, treat publish as done.
+          if [ "$(npm view "@rendobar/mcp@${VERSION}" version 2>/dev/null)" = "$VERSION" ]; then
+            echo "@rendobar/mcp@${VERSION} already published — skipping publish."
+            exit 0
+          fi
           # Retry up to 3 times for transient registry blips.
           for i in 1 2 3; do
             if npm publish --provenance --access public; then
@@ -80,6 +89,11 @@ jobs:
         env:
           VERSION: ${{ steps.tag.outputs.version }}
         run: |
+          # This step drives its own retry loop. GitHub's default `bash -e`
+          # would abort on the first npx miss (slow CDN propagation right after
+          # publish) inside `OUTPUT=$(npx ...)`, before EXIT is even captured —
+          # defeating the backoff entirely. Disable errexit for the loop.
+          set +e
           PKG="@rendobar/mcp@${VERSION}"
           # npm CDN propagation backoff: 30s, 60s, 90s, 120s, 150s.
           # Use `-- --version` so npx unambiguously passes the flag to the bin


### PR DESCRIPTION
## What

The v1.0.2 release published to npm fine but `release.yml` reported failure — the **smoke test** died on attempt 1 (exit 127), skipping *Create GitHub Release* + *MCP registry* and opening issue #13.

## Root cause

The smoke step runs under GitHub's default `bash -e`. Inside the backoff loop, `OUTPUT=$(npx -y @rendobar/mcp@VERSION ...)` returns non-zero when the npm CDN hasn't propagated yet (~30s post-publish). `set -e` aborts the step **before** `EXIT=$?` is captured or any retry runs — the 5×/150s backoff is dead code on a first miss. 1.0.1 got lucky with fast propagation.

## Fix

- `set +e` in the smoke step so its own retry loop owns control flow.
- Make the publish step **idempotent** (skip if the version is already live) so a recovery re-run / manual `workflow_dispatch` to backfill a skipped downstream step doesn't 403 on the existing version.

## Note (already recovered manually)

- npm `@rendobar/mcp@1.0.2` is live + verified (`npx … --version` → 1.0.2).
- GitHub Release v1.0.2 created manually.
- MCP registry still pending — will backfill via `workflow_dispatch` (tag=v1.0.2) once this merges, then close #13.