### PR TITLE
fix(registry): correct server.json schema for MCP registry publish

### DIFF
--- a/server.json
+++ b/server.json
@@ -9,9 +9,10 @@
   "version": "1.0.4",
   "packages": [
     {
-      "registry": "npm",
-      "name": "@rendobar/mcp",
-      "version": "1.0.0"
+      "registryType": "npm",
+      "registryBaseUrl": "https://registry.npmjs.org",
+      "identifier": "@rendobar/mcp",
+      "version": "1.0.4"
     }
   ],
   "transports": [


### PR DESCRIPTION
## Problem

Every release's *Publish to MCP official registry* step 422'd:
```
body.packages[0].identifier:   expected length >= 1, value ""
body.packages[0].registryType: expected length >= 1, value ""
```
`server.json` used the **old** registry keys (`registry`/`name`); mcp-publisher 1.7.6 + the 2025-09-29 schema require `registryType`/`identifier`. The step is `continue-on-error`, so releases stayed green but the server never landed in the official MCP registry. `packages[].version` was also stuck at `1.0.0`.

## Fix

- `registry`→`registryType`, `name`→`identifier`, add `registryBaseUrl`.
- Sync `packages[].version` to the current release so release-please bumps it with the top-level version.

## Why this cuts 1.0.5

mcp-publisher publishes from the checked-out **tag**, so the corrected server.json only takes effect in a new tagged release. 1.0.5 will be the first version to land in the registry — and a full green end-to-end run of the now-fixed pipeline.

npm + GitHub Releases are already current through 1.0.4; this closes the registry gap.