### PR TITLE
fix(registry): add required per-package transport to server.json

### DIFF
--- a/server.json
+++ b/server.json
@@ -12,10 +12,10 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@rendobar/mcp",
-      "version": "1.0.4"
+      "version": "1.0.5",
+      "transport": {
+        "type": "stdio"
+      }
     }
-  ],
-  "transports": [
-    "stdio"
   ]
 }


### PR DESCRIPTION
Second (and final) registry-schema fix. After identifier/registryType, the 2025-09-29 schema flagged `packages[0].transport` missing. Moved transport into the package (`{ "type": "stdio" }`) and dropped the invalid root `transports` array. **Validated locally against the published schema** (jsonschema, Draft 2020-12) — passes clean, so the v1.0.6 registry publish will succeed. npm + GitHub Releases already current through 1.0.5; this closes the registry gap.