### PR TITLE
feat: boot without an API key + Glama listing fixes

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -10,7 +10,10 @@
       "release-type": "node",
       "draft": false,
       "prerelease": false,
-      "extra-files": ["server.json"]
+      "extra-files": [
+        { "type": "json", "path": "server.json", "jsonpath": "$.version" },
+        { "type": "json", "path": "server.json", "jsonpath": "$.packages[0].version" }
+      ]
     }
   }
 }

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,29 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "27 4 * * 1"
+
+jobs:
+  analyze:
+    name: Analyze (javascript-typescript)
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+          queries: security-and-quality
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:javascript-typescript"

--- a/README.md
+++ b/README.md
@@ -137,6 +137,38 @@ env:
 | `cancel_job` | Cancel a waiting/dispatched job. |
 | `get_account` | Check balance, plan limits, active job count. |
 
+### Example
+
+A typical exchange once the server is configured in your client:
+
+> **You:** Mute the first 3 seconds of `~/clips/intro.mp4` and save it.
+
+The agent runs, in order:
+
+```jsonc
+// 1. Stage the local file → returns a hosted download URL
+upload_file { "path": "~/clips/intro.mp4" }
+// → { "downloadUrl": "https://cdn.rendobar.com/u/abc123/intro.mp4", "sizeBytes": 4821004 }
+
+// 2. Submit an FFmpeg job that references it
+submit_job {
+  "type": "raw.ffmpeg",
+  "inputs": { "intro.mp4": "https://cdn.rendobar.com/u/abc123/intro.mp4" },
+  "params": { "command": "-i intro.mp4 -af \"volume=enable='lt(t,3)':volume=0\" -c:v copy out.mp4" }
+}
+// → { "jobId": "job_9f2a", "status": "waiting" }
+
+// 3. Poll until done
+get_job { "jobId": "job_9f2a" }
+// → { "status": "complete", "cost": "$0.01", "output": { "file": { "url": "https://cdn.rendobar.com/o/job_9f2a/out.mp4", "type": "video" } } }
+```
+
+> **Agent:** Done — muted the first 3 seconds. Output: https://cdn.rendobar.com/o/job_9f2a/out.mp4
+
+The server advertises its tools even before an API key is configured, so clients
+and directories can list them; calls that need the API return a clear error until
+`RENDOBAR_API_KEY` is set.
+
 ## Local vs hosted MCP
 
 | | `@rendobar/mcp` (this package) | Hosted MCP (`api.rendobar.com`) |
@@ -171,6 +203,10 @@ Use `"command": "npx.cmd"` instead of `"command": "npx"` if your client doesn't 
 ### Server fails to start
 
 Check logs in your client's output panel. The server writes JSON lines to stderr. Look for entries with `level: "error"`.
+
+### Tools list but calls fail with "No Rendobar API key configured"
+
+Expected when no key is set — the server starts and advertises its tools so clients can list them, but tool calls need an API key. Set `RENDOBAR_API_KEY` (or `--api-key`, or run `rb login`). On startup without a key the server logs a `no_api_key` warning to stderr.
 
 ## Contributing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,26 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in `@rendobar/mcp`, please report it
+privately. **Do not open a public GitHub issue for security problems.**
+
+- Email: **security@rendobar.com**
+- Or use GitHub's [private vulnerability reporting](https://github.com/rendobar/mcp/security/advisories/new).
+
+Please include steps to reproduce, affected versions, and any relevant logs.
+We aim to acknowledge reports within 2 business days and to ship a fix or
+mitigation as quickly as the severity warrants.
+
+## Supported Versions
+
+The latest published `@rendobar/mcp` release on npm receives security updates.
+Please upgrade before reporting an issue to confirm it still reproduces.
+
+## Handling of Credentials
+
+This server reads a Rendobar API key from `--api-key`, the `RENDOBAR_API_KEY`
+environment variable, or a local credentials file. The key is never logged and
+is sent only to the configured Rendobar API base (`https://api.rendobar.com` by
+default) over HTTPS. The server starts without a key so hosts can list its
+tools; tool execution requires the key.

--- a/server.json
+++ b/server.json
@@ -1,7 +1,9 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.rendobar/mcp",
+  "title": "Rendobar",
   "description": "Rendobar — serverless media processing for AI agents",
+  "websiteUrl": "https://rendobar.com/docs/mcp/",
   "repository": {
     "url": "https://github.com/rendobar/mcp",
     "source": "github"
@@ -12,10 +14,19 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@rendobar/mcp",
-      "version": "1.0.5",
+      "version": "1.1.0",
       "transport": {
         "type": "stdio"
-      }
+      },
+      "environmentVariables": [
+        {
+          "name": "RENDOBAR_API_KEY",
+          "description": "Rendobar API key (starts with 'rb_'). Get one at https://app.rendobar.com/settings/api-keys. The server starts without it so tools can be listed, but tool calls require it.",
+          "isRequired": false,
+          "isSecret": true,
+          "format": "string"
+        }
+      ]
     }
   ]
 }

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -99,6 +99,17 @@ async function main(): Promise<void> {
   process.on("SIGINT", () => { void shutdown("SIGINT"); });
   process.on("SIGTERM", () => { void shutdown("SIGTERM"); });
 
+  // Booting without a key is allowed (so hosts can list tools before auth is
+  // configured); warn on stderr so an interactive user notices the misconfig.
+  if (config.apiKey === null) {
+    logger.warn({
+      msg: "no_api_key",
+      detail:
+        "Started without an API key. Tools are listed but will fail when called. " +
+        "Set RENDOBAR_API_KEY to enable them.",
+    });
+  }
+
   // Connect transport.
   const transport = new StdioServerTransport();
   await server.connect(transport);

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,7 +8,15 @@ export class ConfigError extends Error {
 }
 
 export interface ResolvedConfig {
-  apiKey: string;
+  /**
+   * `null` when no key was supplied via any source. The server still boots and
+   * advertises its tools, so hosts can introspect via `tools/list` before the
+   * user configures auth — e.g. directory crawlers like Glama that launch the
+   * server with no credentials, or an IDE that lists tools before prompting for
+   * secrets. The key is required only when a tool is executed; see `getSdk` in
+   * context.ts.
+   */
+  apiKey: string | null;
   apiBase: string;
   logLevel: "debug" | "info" | "warn" | "error";
 }
@@ -42,19 +50,14 @@ export async function parseConfig(opts: ParseConfigOptions): Promise<ResolvedCon
     // file missing or unparseable — silent fallback
   }
 
-  const apiKey = flagKey ?? opts.env.RENDOBAR_API_KEY ?? fileCreds.apiKey;
+  const rawKey = flagKey ?? opts.env.RENDOBAR_API_KEY ?? fileCreds.apiKey;
   const apiBase = flagBase ?? fileCreds.apiBase ?? DEFAULT_API_BASE;
 
-  if (apiKey === undefined || apiKey === "") {
-    throw new ConfigError(
-      `No Rendobar API key found. Provide one via:\n` +
-      `  1. --api-key=<key> command-line flag\n` +
-      `  2. RENDOBAR_API_KEY environment variable\n` +
-      `  3. credentials file at ${opts.credsPath} (written by 'rb login' from CLI v1.1+)\n\n` +
-      `Get an API key at https://app.rendobar.com/settings/api-keys`,
-    );
-  }
-  if (!apiKey.startsWith("rb_")) {
+  // A missing key is NOT an error: the server boots keyless so tools can be
+  // listed (tool execution then fails with a clear message — see getSdk). But a
+  // key that IS present and malformed is a real misconfiguration we surface now.
+  const apiKey = rawKey === undefined || rawKey === "" ? null : rawKey;
+  if (apiKey !== null && !apiKey.startsWith("rb_")) {
     throw new ConfigError(
       `Invalid Rendobar API key: must start with 'rb_' (got '${apiKey.slice(0, 4)}...').`,
     );

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,19 +1,44 @@
 import { createClient, type RendobarClient } from "@rendobar/sdk";
+import { ConfigError } from "./config.js";
 import type { Logger } from "./logger.js";
 import type { ResolvedConfig } from "./config.js";
 
 export interface RendobarContext {
   logger: Logger;
-  sdk: RendobarClient;
+  /**
+   * `null` when the server booted without an API key. Tools are still registered
+   * and listable; they call `getSdk(ctx)` at execute time, which throws a clear
+   * error when the key is missing. Never read `ctx.sdk` directly in a tool.
+   */
+  sdk: RendobarClient | null;
   config: ResolvedConfig;
   /** Cached value populated lazily on first need. Plan limits don't change mid-session. */
   cachedMaxFileSize: number | null;
 }
 
 export function createContext(config: ResolvedConfig, logger: Logger): RendobarContext {
-  const sdk = createClient({
-    apiKey: config.apiKey,
-    baseUrl: config.apiBase,
-  });
+  const sdk =
+    config.apiKey === null
+      ? null
+      : createClient({ apiKey: config.apiKey, baseUrl: config.apiBase });
   return { logger, sdk, config, cachedMaxFileSize: null };
+}
+
+/**
+ * Resolve the SDK client for a tool execution, or throw a user-facing error when
+ * the server was started without credentials. Keeping the key check here (rather
+ * than at boot) is what lets the server advertise its tools to hosts that list
+ * before configuring auth.
+ */
+export function getSdk(ctx: RendobarContext): RendobarClient {
+  if (ctx.sdk === null) {
+    throw new ConfigError(
+      `No Rendobar API key configured. Provide one via:\n` +
+        `  1. --api-key=<key> command-line flag\n` +
+        `  2. RENDOBAR_API_KEY environment variable\n` +
+        `  3. credentials file (written by 'rb login' from the Rendobar CLI)\n\n` +
+        `Get an API key at https://app.rendobar.com/settings/api-keys`,
+    );
+  }
+  return ctx.sdk;
 }

--- a/src/tools/account.ts
+++ b/src/tools/account.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { defineTool } from "./util.js";
+import { getSdk } from "../context.js";
 import type { ZodRawShape } from "zod";
 
 function formatBytes(n: number): string {
@@ -13,7 +14,12 @@ const getAccountTool = defineTool({
   name: "get_account",
   title: "Get Rendobar Account",
   description:
-    "Check credit balance, plan, and limits. Call before submitting expensive jobs to confirm the user can afford them.",
+    "Get the authenticated account's credit balance, plan, and limits. Call this before " +
+    "submitting an expensive job to confirm the balance covers it, or to report the user's " +
+    "remaining credit and plan caps (concurrent jobs, max upload size, job timeout). Takes no " +
+    "arguments. Read-only and idempotent — it never spends credit or changes anything. Requires " +
+    "a configured API key (RENDOBAR_API_KEY); returns an error if none is set, and an " +
+    "INSUFFICIENT_CREDITS / auth error from the API surfaces as a tool error.",
   inputSchema: {} as ZodRawShape,
   outputSchema: {
     balance: z.string(),
@@ -34,7 +40,7 @@ const getAccountTool = defineTool({
     openWorldHint: true,
   },
   execute: async (_args, ctx) => {
-    const state = await ctx.sdk.billing.state();
+    const state = await getSdk(ctx).billing.state();
 
     // Cache the max file size for upload_file's pre-stream gate.
     ctx.cachedMaxFileSize = state.plan.limits.maxInputFileSize;

--- a/src/tools/jobs.ts
+++ b/src/tools/jobs.ts
@@ -1,5 +1,6 @@
 import { z, type ZodRawShape } from "zod";
 import { defineTool, type ToolDef } from "./util.js";
+import { getSdk } from "../context.js";
 
 /**
  * The unified job-result shape returned by `GET /jobs/:id` (and the list endpoint)
@@ -87,14 +88,28 @@ const listJobsTool = defineTool({
   name: "list_jobs",
   title: "List Recent Rendobar Jobs",
   description:
-    "List recent jobs. Use to find previous results, check what's running, or re-reference past outputs.",
+    "List the most recent jobs for the authenticated account, newest first. Use it to find a " +
+    "previous result's output URL, check what is currently running, or recover a job ID you lost. " +
+    "Returns a compact summary per job (id, type, status, createdAt, cost, and a short output " +
+    "summary for completed jobs); call get_job for a job's full output. Optionally filter by " +
+    "status or job type. Read-only — never submits or changes a job. Requires a configured API " +
+    "key (RENDOBAR_API_KEY); errors if none is set.",
   inputSchema: {
     status: z
       .enum(["waiting", "dispatched", "running", "complete", "failed", "cancelled"])
       .optional()
-      .describe("Filter by status"),
-    type: z.string().optional().describe("Filter by job type (e.g. 'raw.ffmpeg')"),
-    limit: z.number().int().min(1).max(50).default(10).describe("Number of jobs to return"),
+      .describe("Only return jobs in this status. Omit to return all statuses."),
+    type: z
+      .string()
+      .optional()
+      .describe("Only return jobs of this type, e.g. 'raw.ffmpeg'. Omit to return all types."),
+    limit: z
+      .number()
+      .int()
+      .min(1)
+      .max(50)
+      .default(10)
+      .describe("How many jobs to return, newest first (1–50, default 10)."),
   },
   annotations: {
     readOnlyHint: true,
@@ -103,7 +118,7 @@ const listJobsTool = defineTool({
     openWorldHint: true,
   },
   execute: async (args, ctx) => {
-    const page = await ctx.sdk.jobs.list({
+    const page = await getSdk(ctx).jobs.list({
       status: args.status,
       type: args.type,
       limit: args.limit,
@@ -152,7 +167,7 @@ const getJobTool = defineTool({
     openWorldHint: true,
   },
   execute: async (args, ctx) => {
-    const job = await ctx.sdk.jobs.get(args.jobId);
+    const job = await getSdk(ctx).jobs.get(args.jobId);
     const shape = parseJobShape(job);
 
     const result: Record<string, unknown> = {
@@ -247,7 +262,7 @@ function buildSubmitJobTool(activeTypes: ReadonlyArray<{ type: string; summary: 
       openWorldHint: true,
     },
     execute: async (args, ctx) => {
-      const result = await ctx.sdk.jobs.create({
+      const result = await getSdk(ctx).jobs.create({
         type: args.type,
         inputs: args.inputs,
         params: args.params,
@@ -277,7 +292,7 @@ const cancelJobTool = defineTool({
     openWorldHint: true,
   },
   execute: async (args, ctx) => {
-    const job = await ctx.sdk.jobs.cancel(args.jobId);
+    const job = await getSdk(ctx).jobs.cancel(args.jobId);
     return { id: job.id, status: job.status };
   },
 });
@@ -311,12 +326,17 @@ export function jobTools(): readonly AnyToolDef[] {
 
 // Async factory used by registerTools at startup. Snapshots active job types
 // once. Description rebuild on registry change requires a server restart (rare).
-export async function jobToolsAsync(sdk: {
-  jobs: { types(): Promise<ReadonlyArray<{ type: string; summary: string }>> };
-}): Promise<readonly AnyToolDef[]> {
+// `sdk` is null when the server booted without an API key: we skip the network
+// fetch and register the tools with a generic description so they remain
+// listable (the key is enforced later, at execute time).
+export async function jobToolsAsync(
+  sdk: {
+    jobs: { types(): Promise<ReadonlyArray<{ type: string; summary: string }>> };
+  } | null,
+): Promise<readonly AnyToolDef[]> {
   let activeTypes: ReadonlyArray<{ type: string; summary: string }> = [];
   try {
-    activeTypes = await sdk.jobs.types();
+    if (sdk !== null) activeTypes = await sdk.jobs.types();
   } catch {
     // If the types fetch fails at startup, fall through to a generic description.
     // Tools still work — just the LLM-facing list of "active types" is empty.

--- a/src/tools/uploads.ts
+++ b/src/tools/uploads.ts
@@ -3,12 +3,13 @@ import { promises as fs } from "node:fs";
 import path from "node:path";
 import { defineTool, type ToolDef, type ToolExtra } from "./util.js";
 import { resolveSafe } from "../paths.js";
+import { getSdk } from "../context.js";
 import type { ZodRawShape } from "zod";
 import type { RendobarContext } from "../context.js";
 
 async function ensureCachedMaxFileSize(ctx: RendobarContext): Promise<number> {
   if (ctx.cachedMaxFileSize !== null) return ctx.cachedMaxFileSize;
-  const state = await ctx.sdk.billing.state();
+  const state = await getSdk(ctx).billing.state();
   ctx.cachedMaxFileSize = state.plan.limits.maxInputFileSize;
   return ctx.cachedMaxFileSize;
 }
@@ -70,7 +71,7 @@ const uploadFileTool = defineTool({
     const buffer = await fs.readFile(resolved);
     const blob = new Blob([buffer]);
 
-    const result = await ctx.sdk.uploads.upload(blob, {
+    const result = await getSdk(ctx).uploads.upload(blob, {
       filename: args.filename ?? path.basename(resolved),
       signal: extra.signal,
     });

--- a/test/integration/server.test.ts
+++ b/test/integration/server.test.ts
@@ -63,10 +63,10 @@ afterEach(() => msw.resetHandlers(
   http.get(`${API_BASE}/jobs/types`, () => HttpResponse.json(jobTypesResponse)),
 ));
 
-async function makeClientServerPair() {
+async function makeClientServerPair(apiKey: string | null = "rb_test") {
   const logger = createLogger({ level: "error" }); // quiet during tests
   const { server, cleanup } = await createRendobarMcpServer({
-    config: { apiKey: "rb_test", apiBase: API_BASE, logLevel: "error" },
+    config: { apiKey, apiBase: API_BASE, logLevel: "error" },
     logger,
   });
   const [clientT, serverT] = InMemoryTransport.createLinkedPair();
@@ -151,6 +151,32 @@ describe("MCP server integration", () => {
     const text = (result.content as Array<{ text: string }>)[0]?.text ?? "{}";
     const payload = JSON.parse(text);
     expect(payload.error.code).toBe("INSUFFICIENT_CREDITS");
+    await client.close();
+    await cleanup();
+  });
+});
+
+// Regression for the Glama "No tools" failure: a directory crawler launches the
+// server with NO credentials and calls tools/list. The server must boot and
+// advertise all tools anyway, then fail cleanly only when a tool is executed.
+describe("MCP server boots without an API key", () => {
+  it("still lists all 6 tools when started keyless", async () => {
+    const { client, cleanup } = await makeClientServerPair(null);
+    const tools = await client.listTools();
+    const names = new Set(tools.tools.map((t) => t.name));
+    for (const name of ["get_account", "list_jobs", "get_job", "submit_job", "cancel_job", "upload_file"]) {
+      expect(names.has(name)).toBe(true);
+    }
+    await client.close();
+    await cleanup();
+  });
+
+  it("returns a clear error (no network call) when a tool runs without a key", async () => {
+    const { client, cleanup } = await makeClientServerPair(null);
+    const result = await client.callTool({ name: "get_account", arguments: {} });
+    expect(result.isError).toBe(true);
+    const text = (result.content as Array<{ text: string }>)[0]?.text ?? "";
+    expect(text).toContain("RENDOBAR_API_KEY");
     await client.close();
     await cleanup();
   });

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -78,10 +78,19 @@ describe("parseConfig", () => {
     ).rejects.toThrow(ConfigError);
   });
 
-  it("throws ConfigError when no key in any source", async () => {
-    await expect(
-      parseConfig({ argv: [], env: {}, credsPath: "/no/such/file" }),
-    ).rejects.toThrow(ConfigError);
+  it("returns apiKey null when no key in any source (server boots keyless for tool listing)", async () => {
+    const cfg = await parseConfig({ argv: [], env: {}, credsPath: "/no/such/file" });
+    expect(cfg.apiKey).toBeNull();
+    expect(cfg.apiBase).toBe("https://api.rendobar.com");
+  });
+
+  it("treats an empty-string api key as no key (null), not an error", async () => {
+    const cfg = await parseConfig({
+      argv: [],
+      env: { RENDOBAR_API_KEY: "" },
+      credsPath: "/no/such/file",
+    });
+    expect(cfg.apiKey).toBeNull();
   });
 
   it("respects RENDOBAR_LOG_LEVEL env", async () => {


### PR DESCRIPTION
## Why

`@rendobar/mcp` showed a low score on its [Glama listing](https://glama.ai/mcp/servers/rendobar/mcp): **"No tools detected"**, **"cannot be installed"**, License/Quality/Security **"not tested"**, grade **C**.

Root cause (verified against Glama's [own indexing docs](https://glama.ai/blog/2025-01-04-automating-issue-detection)): Glama enumerates tools by **launching the server in a container and calling `tools/list`**. Servers that can't boot without credentials land in its `requires_valid_credentials` bucket and index zero tools. Our `bin.ts` threw in `parseConfig()` when no API key was present, **before** any tool registered — so a keyless launch exited immediately. This also affects any MCP host that lists tools before the user configures auth.

## What

- **Lazy auth (core fix):** the server now boots with no API key, registers and advertises all six tools, and only requires the key when a tool is **executed**. `parseConfig` returns `apiKey: null` for a missing key (a malformed key that *is* present is still rejected); tools resolve the SDK via `getSdk()`, which throws a clear `set RENDOBAR_API_KEY` error at call time; `jobToolsAsync` skips its startup network fetch when keyless; `bin.ts` logs a `no_api_key` warning to stderr.
- **`server.json`:** fixed nested `packages[0].version` drift (`1.0.5` → `1.1.0`) and reconfigured release-please `extra-files` with explicit json updaters so `$.version` and `$.packages[0].version` track every release. Declared `RENDOBAR_API_KEY` (env var) plus `title`/`websiteUrl`.
- **Security signals:** repo-local `SECURITY.md` and a CodeQL workflow.
- **Docs / tool quality:** enriched the `get_account` and `list_jobs` tool descriptions (auth, errors, semantics) and added a worked usage example + keyless troubleshooting note to the README.

## Test plan

- `typecheck`, `lint`, full `vitest` suite green (56 tests).
- New integration tests: keyless boot still lists all six tools; a keyless tool call fails with a clear, network-free error.
- Verified on the built artifact: launching `dist/bin.js` with no key (isolated empty `APPDATA`/`HOME`) returns all six tools over stdio and emits only the warning on stderr — no stdout pollution.

## Follow-up (manual, owner-only)

After this merges and a release publishes, claim the server on Glama (log in as `a-essawy`, the `glama.json` maintainer) and trigger a re-sync so it re-introspects: License → A, Quality tested, tools listed, "installable".
