### PR TITLE
fix: align advertised job types and resolve CodeQL alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
   <a href="https://www.npmjs.com/package/@rendobar/mcp"><img src="https://img.shields.io/npm/dm/@rendobar/mcp?style=flat-square&color=059669" alt="npm downloads"></a>
   <img src="https://img.shields.io/npm/l/@rendobar/mcp?style=flat-square&color=059669" alt="MIT license">
   <img src="https://img.shields.io/node/v/@rendobar/mcp?style=flat-square&color=059669" alt="Node version">
+  <a href="https://glama.ai/mcp/servers/kwdj3f0u3z"><img src="https://glama.ai/mcp/servers/kwdj3f0u3z/badge" alt="Glama quality" height="20"></a>
 </p>
 
 ---

--- a/README.md
+++ b/README.md
@@ -131,11 +131,21 @@ env:
 | Tool | Purpose |
 |---|---|
 | `upload_file` | Upload a local file. Returns a download URL to use in `submit_job`. |
-| `submit_job` | Submit any Rendobar job. Description lists active job types. |
+| `submit_job` | Submit any Rendobar job. Its description lists the active job types. |
 | `get_job` | Poll job status, fetch result. |
 | `list_jobs` | List recent jobs. |
 | `cancel_job` | Cancel a waiting/dispatched job. |
 | `get_account` | Check balance, plan limits, active job count. |
+
+### Job types
+
+`submit_job` takes a `type`. The active types:
+
+| `type` | What it does |
+|---|---|
+| `ffmpeg` | Run any FFmpeg command (transcode, trim, mux, filter, concat). |
+| `captions.animate` | Burn animated word-level captions onto a video (Hormozi / MrBeast / TikTok / pill presets). |
+| `caption.burn` | Burn static styled subtitles from an SRT/VTT/ASS file, or auto-transcribe when none is given. |
 
 ### Example
 
@@ -152,7 +162,7 @@ upload_file { "path": "~/clips/intro.mp4" }
 
 // 2. Submit an FFmpeg job that references it
 submit_job {
-  "type": "raw.ffmpeg",
+  "type": "ffmpeg",
   "inputs": { "intro.mp4": "https://cdn.rendobar.com/u/abc123/intro.mp4" },
   "params": { "command": "-i intro.mp4 -af \"volume=enable='lt(t,3)':volume=0\" -c:v copy out.mp4" }
 }
@@ -164,6 +174,17 @@ get_job { "jobId": "job_9f2a" }
 ```
 
 > **Agent:** Done — muted the first 3 seconds. Output: https://cdn.rendobar.com/o/job_9f2a/out.mp4
+
+Auto-caption a clip with animated word-level captions — no subtitle file needed:
+
+```jsonc
+submit_job {
+  "type": "captions.animate",
+  "inputs": { "clip.mp4": "https://cdn.rendobar.com/u/abc123/clip.mp4" },
+  "params": { "preset": "hormozi" }
+}
+// → { "jobId": "job_7c1b", "status": "waiting" }
+```
 
 The server advertises its tools even before an API key is configured, so clients
 and directories can list them; calls that need the API return a clear error until

--- a/src/instructions.ts
+++ b/src/instructions.ts
@@ -1,8 +1,12 @@
-export const SERVER_INSTRUCTIONS = `Rendobar processes existing media files via FFmpeg in the cloud.
+export const SERVER_INSTRUCTIONS = `Rendobar processes existing media files in the cloud.
 
-Active job type:
-  raw.ffmpeg — run a custom FFmpeg command. inputs maps logical names to URLs;
-               params.command is the FFmpeg command using those names as filenames.
+Active job types:
+  ffmpeg — run a custom FFmpeg command. inputs maps logical names to URLs;
+           params.command is the FFmpeg command using those names as filenames.
+  captions.animate — burn animated word-level captions onto a video
+                     (Hormozi / MrBeast / TikTok / pill presets).
+  caption.burn — burn static styled subtitles into a video from an SRT/VTT/ASS
+                 file, or auto-transcribe when none is given.
 
 Workflow:
 1. If the file is at a public HTTPS URL, pass it directly to submit_job as inputs.source (or another input name referenced by your command).
@@ -14,6 +18,6 @@ What Rendobar cannot do:
 - Generate video from text or images (no diffusion models)
 - Record screens or capture cameras
 - Stream live media
-- Run other binaries (ffprobe, sharp, imagemagick) — only ffmpeg
+- Run arbitrary local binaries (sharp, imagemagick, yt-dlp) — only the job types above
 
-For anything outside FFmpeg, tell the user instead of improvising locally.`;
+For anything outside the supported job types, tell the user instead of improvising locally.`;

--- a/src/tools/jobs.ts
+++ b/src/tools/jobs.ts
@@ -102,7 +102,7 @@ const listJobsTool = defineTool({
     type: z
       .string()
       .optional()
-      .describe("Only return jobs of this type, e.g. 'raw.ffmpeg'. Omit to return all types."),
+      .describe("Only return jobs of this type, e.g. 'ffmpeg'. Omit to return all types."),
     limit: z
       .number()
       .int()
@@ -226,7 +226,7 @@ const inputSourceSchema = z.union([
 ]);
 
 const submitJobInputSchema = {
-  type: z.string().describe("Job type from registry. Use 'raw.ffmpeg' for custom FFmpeg commands."),
+  type: z.string().describe("Job type from registry. Use 'ffmpeg' for custom FFmpeg commands."),
   inputs: z
     .record(z.string(), inputSourceSchema)
     .describe(
@@ -235,18 +235,39 @@ const submitJobInputSchema = {
   params: z
     .record(z.string(), z.unknown())
     .optional()
-    .describe("Type-specific parameters. For raw.ffmpeg: { command: '...' }"),
+    .describe("Type-specific parameters. For ffmpeg: { command: '...' }"),
   idempotencyKey: z
     .string()
     .optional()
     .describe("Prevents duplicate jobs on retry. Unique value per logical operation."),
 };
 
+// Keyless fallback. The server can boot without an API key (directory indexers
+// like Glama launch it to read tools/list, and the live registry fetch needs a
+// key), so we always advertise the currently featured job types. When a key IS
+// present, sdk.jobs.types() overrides this with the live registry. Keep this set
+// in sync with the featured job types on https://rendobar.com/llms.txt.
+const FEATURED_JOB_TYPES: ReadonlyArray<{ type: string; summary: string }> = [
+  {
+    type: "ffmpeg",
+    summary:
+      "Run any FFmpeg command on hosted infrastructure (transcode, trim, mux, filter, concat).",
+  },
+  {
+    type: "captions.animate",
+    summary:
+      "Burn animated word-level captions onto a video (Hormozi / MrBeast / TikTok / pill presets).",
+  },
+  {
+    type: "caption.burn",
+    summary:
+      "Burn static styled subtitles into a video from an SRT/VTT/ASS file, or auto-transcribe when none is given.",
+  },
+];
+
 function buildSubmitJobTool(activeTypes: ReadonlyArray<{ type: string; summary: string }>) {
-  const typesText =
-    activeTypes.length > 0
-      ? `\n\nActive job types:\n${activeTypes.map((t) => `  ${t.type} — ${t.summary}`).join("\n")}`
-      : "";
+  const types = activeTypes.length > 0 ? activeTypes : FEATURED_JOB_TYPES;
+  const typesText = `\n\nActive job types:\n${types.map((t) => `  ${t.type} — ${t.summary}`).join("\n")}`;
   return defineTool({
     name: "submit_job",
     title: "Submit Rendobar Job",

--- a/src/tools/uploads.ts
+++ b/src/tools/uploads.ts
@@ -40,45 +40,53 @@ const uploadFileTool = defineTool({
     // 1. Resolve path safely.
     const resolved = await resolveSafe(args.path, { cwd: process.cwd() });
 
-    // 2. Stat — must be a regular file with size we can check.
-    const stat = await fs.stat(resolved);
-    if (!stat.isFile()) {
-      throw new Error(`Path is not a regular file: ${path.basename(resolved)}`);
+    // 2. Open the file once and operate on the handle. Statting by path and then
+    //    re-reading by path opens a TOCTOU window (the path could be swapped for
+    //    a symlink between the two calls). A single FileHandle for both stat and
+    //    read closes that window.
+    const fh = await fs.open(resolved, "r");
+    try {
+      const stat = await fh.stat();
+      if (!stat.isFile()) {
+        throw new Error(`Path is not a regular file: ${path.basename(resolved)}`);
+      }
+      const sizeBytes = stat.size;
+
+      // 3. Pre-stream size gate. Lazily fetch the limit if cold.
+      const maxFileSize = await ensureCachedMaxFileSize(ctx);
+      if (sizeBytes > maxFileSize) {
+        throw new Error(
+          `File size (${sizeBytes} bytes) exceeds plan limit (${maxFileSize} bytes). ` +
+            `Upgrade your plan for larger uploads.`,
+        );
+      }
+
+      ctx.logger.debug({ msg: "upload_start", basename: path.basename(resolved), sizeBytes });
+
+      // 4. Read into memory and upload as a Blob.
+      //
+      // Streaming via Readable.toWeb(...) hit "RequestInit: duplex option is required
+      // when sending a body" because Node's fetch requires duplex:'half' for stream
+      // bodies and the SDK request layer doesn't set it. Buffering avoids that
+      // entirely — Blob is a fully-buffered BodyInit and works everywhere.
+      //
+      // Memory bound: maxInputFileSize (free=100MB, pro=2GB) — same ceiling the
+      // pre-stream gate enforces. v2 candidate: patch SDK to set duplex, then
+      // restore streaming + ProgressTransform for files >5MB.
+      const buffer = await fh.readFile();
+      const blob = new Blob([buffer]);
+
+      const result = await getSdk(ctx).uploads.upload(blob, {
+        filename: args.filename ?? path.basename(resolved),
+        signal: extra.signal,
+      });
+
+      ctx.logger.info({ msg: "upload_complete", basename: path.basename(resolved), sizeBytes });
+
+      return { downloadUrl: result.downloadUrl, sizeBytes };
+    } finally {
+      await fh.close();
     }
-    const sizeBytes = stat.size;
-
-    // 3. Pre-stream size gate. Lazily fetch the limit if cold.
-    const maxFileSize = await ensureCachedMaxFileSize(ctx);
-    if (sizeBytes > maxFileSize) {
-      throw new Error(
-        `File size (${sizeBytes} bytes) exceeds plan limit (${maxFileSize} bytes). ` +
-          `Upgrade your plan for larger uploads.`,
-      );
-    }
-
-    ctx.logger.debug({ msg: "upload_start", basename: path.basename(resolved), sizeBytes });
-
-    // 4. Read into memory and upload as a Blob.
-    //
-    // Streaming via Readable.toWeb(...) hit "RequestInit: duplex option is required
-    // when sending a body" because Node's fetch requires duplex:'half' for stream
-    // bodies and the SDK request layer doesn't set it. Buffering avoids that
-    // entirely — Blob is a fully-buffered BodyInit and works everywhere.
-    //
-    // Memory bound: maxInputFileSize (free=100MB, pro=2GB) — same ceiling the
-    // pre-stream gate enforces. v2 candidate: patch SDK to set duplex, then
-    // restore streaming + ProgressTransform for files >5MB.
-    const buffer = await fs.readFile(resolved);
-    const blob = new Blob([buffer]);
-
-    const result = await getSdk(ctx).uploads.upload(blob, {
-      filename: args.filename ?? path.basename(resolved),
-      signal: extra.signal,
-    });
-
-    ctx.logger.info({ msg: "upload_complete", basename: path.basename(resolved), sizeBytes });
-
-    return { downloadUrl: result.downloadUrl, sizeBytes };
   },
 });
 

--- a/test/e2e-real.mjs
+++ b/test/e2e-real.mjs
@@ -9,7 +9,6 @@
  */
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
-import { promises as fs } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 


### PR DESCRIPTION
## Why

The Glama listing (https://glama.ai/mcp/servers/rendobar/mcp) is now grade A/A/B with all 6 tools after the keyless-boot fix in #28. But indexers read the server by launching it **without an API key**, so they only ever see the *static* tool descriptions — and those had drifted:

- They still named the old `raw.ffmpeg` job type (renamed to `ffmpeg` in prod on 2026-06-03).
- They advertised a **single** active job type, so the listing looked like a custom-FFmpeg-only server and hid captions support.

Two open CodeQL alerts also drag the Security signal.

## What

- **Rename `raw.ffmpeg` → `ffmpeg`** across tool descriptions, server instructions, and the README example.
- **Advertise the featured job types even when keyless** — `ffmpeg`, `captions.animate`, `caption.burn` — so directory indexers and clients see the real surface. A configured API key still overrides this with the live registry via `sdk.jobs.types()`. Kept in sync with llms.txt.
- **Fix `js/file-system-race` (high)** in `upload_file`: open the file once and use a single `FileHandle` for stat + read, closing the TOCTOU window between checking and reading the path.
- **Fix `js/unused-local-variable`**: drop the unused `fs` import in the e2e test.
- Document the job types and add a `captions.animate` example in the README.

## Test plan

- `tsc --noEmit` clean
- `eslint src test` clean
- `vitest run` — 56 passing
- `tsup` build clean
- Keyless smoke test (`RENDOBAR_API_KEY= node dist/bin.js`): `tools/list` returns all 6 tools and `submit_job`'s description lists the 3 job types — exactly what Glama indexes.

After merge + release, trigger a Glama re-sync so the listing picks up the corrected job-type surface.