### PR TITLE
feat: document optional ffmpeg compute (gpu) param in submit_job

### DIFF
--- a/src/instructions.ts
+++ b/src/instructions.ts
@@ -3,6 +3,8 @@ export const SERVER_INSTRUCTIONS = `Rendobar processes existing media files in t
 Active job types:
   ffmpeg — run a custom FFmpeg command. inputs maps logical names to URLs;
            params.command is the FFmpeg command using those names as filenames.
+           Optional params.compute ('auto' | 'cpu' | 'gpu') defaults to 'auto',
+           routing NVENC/CUDA commands to a GPU; 'gpu' forces GPU (NVIDIA L4, Pro plan).
   captions.animate — burn animated word-level captions onto a video
                      (Hormozi / MrBeast / TikTok / pill presets).
   caption.burn — burn static styled subtitles into a video from an SRT/VTT/ASS

--- a/src/tools/jobs.ts
+++ b/src/tools/jobs.ts
@@ -211,7 +211,10 @@ const submitJobBaseDescription =
   `Rendobar runs the job on its own infrastructure and returns a hosted output URL.\n\n` +
   `FFmpeg inputs accept a URL string, { url }, { content } (inline text staged verbatim ` +
   `into the workdir, for subtitle files or ffmpeg concat lists), or { ref } (an ` +
-  `already-uploaded asset, by its asset ID). The bare URL string and { url } are equivalent.`;
+  `already-uploaded asset, by its asset ID). The bare URL string and { url } are equivalent.\n\n` +
+  `FFmpeg also accepts an optional params.compute ('auto' | 'cpu' | 'gpu'). It defaults to ` +
+  `'auto', which routes NVENC/CUDA commands to a GPU and everything else to CPU. Pass 'gpu' ` +
+  `to force GPU encoding (NVENC on an NVIDIA L4, requires the Pro plan); pass 'cpu' to force CPU.`;
 
 // Polymorphic ffmpeg input source — mirrors inputSourceSchema in the API
 // (packages/shared/src/jobs/definitions/shared.ts) and the remote MCP tool. Each
@@ -235,7 +238,11 @@ const submitJobInputSchema = {
   params: z
     .record(z.string(), z.unknown())
     .optional()
-    .describe("Type-specific parameters. For ffmpeg: { command: '...' }"),
+    .describe(
+      "Type-specific parameters. For ffmpeg: { command: '...', compute?: 'auto' | 'cpu' | 'gpu' } — " +
+        "compute defaults to 'auto' and routes NVENC/CUDA commands to a GPU; 'gpu' forces GPU " +
+        "encoding (NVIDIA L4, Pro plan), 'cpu' forces CPU.",
+    ),
   idempotencyKey: z
     .string()
     .optional()


### PR DESCRIPTION
## What

The `ffmpeg` job type now accepts an optional `compute` param (`"auto" | "cpu" | "gpu"`), with GPU (NVENC on NVIDIA L4, Pro plan) now live. This surfaces it to agents in the `submit_job` tool so they can request GPU encoding.

Description-only change. No schema change: `params` is already a generic `z.record(z.string(), z.unknown())` passthrough, so `compute` flows through to the API unchanged. No new typed field added (keeps params as the intentional passthrough).

## Changes

- `src/tools/jobs.ts`: extend the `submit_job` base description and the `params` `.describe(...)` to mention `compute?: 'auto' | 'cpu' | 'gpu'` — defaults to `auto` (NVENC/CUDA commands auto-route to GPU); `'gpu'` forces GPU encoding (NVIDIA L4, Pro plan); `'cpu'` forces CPU.
- `src/instructions.ts`: one-line GPU note on the ffmpeg capability.

## Test plan

- `pnpm typecheck` — clean
- `pnpm lint` — clean
- `pnpm test` — 56/56 pass
- `pnpm build` — success, `dist/bin.js` 17.46 KB (under 100KB budget)

npm release is a separate step.