### PR TITLE
docs: update captions.animate description for the expanded job

### DIFF
--- a/src/instructions.ts
+++ b/src/instructions.ts
@@ -5,8 +5,9 @@ Active job types:
            params.command is the FFmpeg command using those names as filenames.
            Optional params.compute ('auto' | 'cpu' | 'gpu') defaults to 'auto',
            routing NVENC/CUDA commands to a GPU; 'gpu' forces GPU (NVIDIA L4, Pro plan).
-  captions.animate — burn animated word-level captions onto a video
-                     (Hormozi / MrBeast / TikTok / pill presets).
+  captions.animate — burn animated word-level captions onto a video. Style
+                     presets, position, translation, AI keyword highlighting,
+                     SRT/VTT output, bring-your-own-transcript.
   caption.burn — burn static styled subtitles into a video from an SRT/VTT/ASS
                  file, or auto-transcribe when none is given.
 

--- a/src/tools/jobs.ts
+++ b/src/tools/jobs.ts
@@ -263,7 +263,7 @@ const FEATURED_JOB_TYPES: ReadonlyArray<{ type: string; summary: string }> = [
   {
     type: "captions.animate",
     summary:
-      "Burn animated word-level captions onto a video (Hormozi / MrBeast / TikTok / pill presets).",
+      "Burn animated word-level captions onto a video. Built-in style presets, custom position, translation, AI keyword highlighting, SRT/VTT output, and bring-your-own-transcript.",
   },
   {
     type: "caption.burn",


### PR DESCRIPTION
# Update captions.animate description for the expanded job

The captions.animate job grew a lot (companion to the backend PR in rendobar/rendobar): style presets, custom position/entrance, translation, AI keyword highlighting, SRT/VTT output, and bring-your-own-transcript. This refreshes the two agent-facing descriptions that still listed only the original 4 presets.

- `src/instructions.ts` — the server instructions block.
- `src/tools/jobs.ts` — the captions.animate tool summary.

Copy-only. The tool's params are a generic passthrough (`params: Record<string, unknown>`), so no schema change is needed — agents could already send the new params; this just makes the description accurate.

typecheck + 56 tests + build all green.

## Merge order
Land after the backend captions PR deploys, so the description doesn't advertise capabilities that aren't live yet.
